### PR TITLE
change nib.get_data to nib.get_fdata

### DIFF
--- a/gif_your_nifti/core.py
+++ b/gif_your_nifti/core.py
@@ -49,7 +49,7 @@ def load_and_prepare_image(filename, size=1):
 
     """
     # Load NIfTI file
-    data = nb.load(filename).get_data()
+    data = nb.load(filename).get_fdata()
 
     # Pad data array with zeros to make the shape isometric
     maximum = np.max(data.shape)


### PR DESCRIPTION
From Nibabel "
get_data() is deprecated in favor of get_fdata(), which has a more predictable return type. To obtain get_data() behavior going forward, use numpy.asanyarray(img.dataobj).

deprecated from version: 3.0
Raises <class ‘nibabel.deprecator.ExpiredDeprecationError’> as of version: 5.0" 

I changed the get_data in the core.py to get_fdata. 
Thank you if you can merge my fix to the master branch!